### PR TITLE
Updating SR_IOV_MultipleVFCreation_withMTU to only run on the first pf, as per specification/discussion

### DIFF
--- a/sriov/tests/SR_IOV_MultipleVFCreation_withMTU/test_SR_IOV_MultipleVFCreation_withMTU.py
+++ b/sriov/tests/SR_IOV_MultipleVFCreation_withMTU/test_SR_IOV_MultipleVFCreation_withMTU.py
@@ -11,46 +11,46 @@ LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.parametrize('execution_number', range(1))
 def test_SRIOVMultipleVFCreationwithMTU(dut, settings, testdata, execution_number):
-    for pf in testdata['pfs']:
-        base_mac = "0x0000000000"
+    pf = list(testdata['pfs'].keys())[0] 
+    base_mac = "0x0000000000"
 
-        max_vfs_cmd = "cat " + testdata['pf_net_paths'][pf] + "/sriov_totalvfs"
-        code, out, err = dut.execute(max_vfs_cmd)
-        assert code == 0
-        max_vfs = out[0].strip()
+    max_vfs_cmd = "cat " + testdata['pf_net_paths'][pf] + "/sriov_totalvfs"
+    code, out, err = dut.execute(max_vfs_cmd)
+    assert code == 0
+    max_vfs = out[0].strip()
     
-        set_vfs = "echo " + max_vfs + " > " + testdata['pf_net_paths'][pf] + "/sriov_numvfs"
-        code, out, err = dut.execute(set_vfs)
-        assert code == 0
+    set_vfs = "echo " + max_vfs + " > " + testdata['pf_net_paths'][pf] + "/sriov_numvfs"
+    code, out, err = dut.execute(set_vfs)
+    assert code == 0
 
-        code, out, err = dut.execute('sleep 2')
-        assert code == 0
+    code, out, err = dut.execute('sleep 2')
+    assert code == 0
 
-        check_vfs = "ip -d link show " + testdata['pfs'][pf]['name']
-        code, out, err = dut.execute(check_vfs)
-        assert code == 0
-        for out_slice in out:
-            assert "00:00:00:00:00:00" not in out_slice
+    check_vfs = "ip -d link show " + testdata['pfs'][pf]['name']
+    code, out, err = dut.execute(check_vfs)
+    assert code == 0
+    for out_slice in out:
+        assert "00:00:00:00:00:00" not in out_slice
     
-        split_out = out[1].split()
-        max_mtu = split_out[split_out.index("maxmtu") + 1]
+    split_out = out[1].split()
+    max_mtu = split_out[split_out.index("maxmtu") + 1]
 
-        set_max_mtu = "ip link set " + testdata['pfs'][pf]['name'] + " mtu " + max_mtu
-        code, out, err = dut.execute(set_max_mtu)
-        assert code == 0
+    set_max_mtu = "ip link set " + testdata['pfs'][pf]['name'] + " mtu " + max_mtu
+    code, out, err = dut.execute(set_max_mtu)
+    assert code == 0
 
-        for i in range(int(max_vfs)):
-            # Reference for incrementing mac addresses: https://stackoverflow.com/a/62210098
-            base_mac = "{:012X}".format(int(base_mac, 16) + 1)
-            new_mac = ":".join(base_mac[i]+base_mac[i+1] for i in range(0, len(base_mac), 2))
-            steps = ["ip link set " + testdata['pfs'][pf]['name'] + " vf " + str(i) + " mac " + new_mac,
-                     "sleep 0.5",
-                     "ip link set " + testdata['pfs'][pf]['name'] + "v" + str(i) + " mtu " + max_mtu
-                    ]
-            for step in steps:
-                code, out, err = dut.execute(step)
-                assert code == 0, step
+    for i in range(int(max_vfs)):
+        # Reference for incrementing mac addresses: https://stackoverflow.com/a/62210098
+        base_mac = "{:012X}".format(int(base_mac, 16) + 1)
+        new_mac = ":".join(base_mac[i]+base_mac[i+1] for i in range(0, len(base_mac), 2))
+        steps = ["ip link set " + testdata['pfs'][pf]['name'] + " vf " + str(i) + " mac " + new_mac,
+                 "sleep 0.5",
+                 "ip link set " + testdata['pfs'][pf]['name'] + "v" + str(i) + " mtu " + max_mtu
+                ]
+        for step in steps:
+            code, out, err = dut.execute(step)
+            assert code == 0, step
 
-        set_mtu = "ip link set " + testdata['pfs'][pf]['name'] + " mtu 1500"
-        code, out, err = dut.execute(set_mtu)
-        assert code == 0
+    set_mtu = "ip link set " + testdata['pfs'][pf]['name'] + " mtu 1500"
+    code, out, err = dut.execute(set_mtu)
+    assert code == 0

--- a/sriov/tests/SR_IOV_MultipleVFCreation_withMTU/test_SR_IOV_MultipleVFCreation_withMTU.py
+++ b/sriov/tests/SR_IOV_MultipleVFCreation_withMTU/test_SR_IOV_MultipleVFCreation_withMTU.py
@@ -5,8 +5,6 @@ import logging
 from sriov.common.exec import ShellHandler
 from sriov.common.config import Config
 
-from pytest_html import extras
-
 LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.parametrize('execution_number', range(1))


### PR DESCRIPTION
Just a quick change to the existing robustness test so it only runs on the first pf
Copy of the report:
https://gist.github.com/dkosteck/ef1a411b04de81bff679c303384d361c