### PR TITLE
Repo maintenance: change config template name, add docutils to requirements.txt

### DIFF
--- a/sriov/requirements.txt
+++ b/sriov/requirements.txt
@@ -2,3 +2,4 @@ paramiko==2.11.0
 pytest==6.2.5
 PyYAML==6.0
 pytest-html
+docutils

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -3,10 +3,10 @@ tests_name_field: "Test Case Name:"
 tests_doc_file: "README.md"
 github_tests_path: "https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests"
 dut:
-  host: "192.168.49.134"
+  host: "DUT ip address"
   username: root
-  password: "redhat"
-  pmd_cpus: "30,32,34"
+  password: "root password"
+  pmd_cpus: "cpu list for testpmd"
   interface:
     pf1:
       name: "ens7f3"
@@ -15,11 +15,10 @@ dut:
       name: "ens7f3v0"
       pci: "0000:ca:19.0"
 trafficgen:
-  host: "192.168.49.147"
+  host: "TrafficGen ip address"
   username: root
-  password: "redhat"
+  password: "root password"
   interface:
     pf1:
       name: "ens8f0"
       mac: "40:a6:b7:2b:19:a0"
-

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -3,10 +3,10 @@ tests_name_field: "Test Case Name:"
 tests_doc_file: "README.md"
 github_tests_path: "https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests"
 dut:
-  host: "DUT ip address"
+  host: "192.168.49.134"
   username: root
-  password: "root password"
-  pmd_cpus: "cpu list for testpmd"
+  password: "redhat"
+  pmd_cpus: "30,32,34"
   interface:
     pf1:
       name: "ens7f3"
@@ -15,10 +15,11 @@ dut:
       name: "ens7f3v0"
       pci: "0000:ca:19.0"
 trafficgen:
-  host: "TrafficGen ip address"
+  host: "192.168.49.147"
   username: root
-  password: "root password"
+  password: "redhat"
   interface:
     pf1:
       name: "ens8f0"
       mac: "40:a6:b7:2b:19:a0"
+


### PR DESCRIPTION
A couple of small items to make our life easier: 
1. Rename config.yaml to config_template.yaml, so .gitignore works for actual config.yaml;
2. Add docutils to requirements.txt. 