### PR TITLE
SR-IOV.TrustMode: ignore an error when trying to change mac address in trust mode off

### DIFF
--- a/sriov/tests/SR_IOV_TrustMode/README.md
+++ b/sriov/tests/SR_IOV_TrustMode/README.md
@@ -18,10 +18,17 @@ ip link set ${DUT_PF}v0 up
 
 * Read VF 0 mac address and assert it is equal to ${MAC_2}
 
-* On DUT, assert on 0 exit code of each of the following steps,
+* On DUT, assert on 0 exit code of the following step,
+
 ```
 ip link set ${DUT_PF} vf 0 trust off
+```
+
+* The next step is expected to produce an error,
+  
+```
 ip link set ${DUT_PF}v0 address ${MAC_3}
+RTNETLINK answers: Permission denied
 ```
 
 * Read VF 0 mac address and assert it is not equal to ${MAC_3}

--- a/sriov/tests/SR_IOV_TrustMode/test_SR_IOV_TrustMode.py
+++ b/sriov/tests/SR_IOV_TrustMode/test_SR_IOV_TrustMode.py
@@ -23,25 +23,31 @@ def test_SR_IOV_TrustMode(dut, settings):
 
     # check if vf 0 mac address is equal to mac_2
     cmd = "ip link show {}".format(pf) + " | awk '/vf 0/{print $4;}'"
+    print(cmd)
     code, out, err = dut.execute(cmd)
     assert code == 0, err
     vf_mac = out[0].strip("\n")
+    print(vf_mac)
     assert vf_mac == mac_2
     
-    # set trust mode to on
-    steps = [
-        f"ip link set {pf} vf 0 trust off",
-        f"ip link set {pf}v0 address {mac_3}"
-        ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(0.1)
-        
+    # set trust mode to off
+    cmd = "ip link set {}".format(pf) + " vf 0 trust off"
+    print(cmd)
+    code, out, err = dut.execute(cmd)
+    assert code == 0, err
+    time.sleep(0.1)
+    
+    # try to overwrite mac_2 with mac_3
+    cmd = "ip link set {}".format(pf) + "v0 address {}".format(mac_3)
+    print(cmd)
+    code, out, err = dut.execute(cmd)
+    print(err[0].strip("\n"))
+           
     # check if vf 0 mac address is NOT equal to mac_3
     cmd = "ip link show {}".format(pf) + " | awk '/vf 0/{print $4;}'"
+    print(cmd)
     code, out, err = dut.execute(cmd)
     assert code == 0, err
     vf_mac = out[0].strip("\n")
+    print(vf_mac)
     assert vf_mac != mac_3    


### PR DESCRIPTION
This is a PR to resolve #27.

Updated passed test output:
------------------------------Captured stdout call------------------------------
echo 0 > /sys/class/net/ens7f3/device/sriov_numvfs
echo 1 > /sys/class/net/ens7f3/device/sriov_numvfs
ip link set ens7f3v0 down
ip link set ens7f3 vf 0 mac aa:bb:cc:dd:ee:11
ip link set ens7f3 vf 0 trust on
ip link set ens7f3v0 address aa:bb:cc:dd:ee:22
ip link set ens7f3v0 up
ip link show ens7f3 | awk '/vf 0/{print $4;}'
aa:bb:cc:dd:ee:22
ip link set ens7f3 vf 0 trust off
ip link set ens7f3v0 address aa:bb:cc:dd:ee:33
RTNETLINK answers: Permission denied
ip link show ens7f3 | awk '/vf 0/{print $4;}'
aa:bb:cc:dd:ee:22