### PR TITLE
Fix SR_IOV_macAddress_DPDK timing issue with RT kernel

### DIFF
--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -231,6 +231,27 @@ def vfs_created(ssh_obj, pf_interface, num_vfs, timeout = 10):
             return True
     return False
 
+def create_vfs(ssh_obj, pf_interface, num_vfs, timeout = 10):
+    """ Create the num_vfs of pf_interface
+    
+    Args:
+        ssh_obj:            ssh connection obj
+        pf_interface (str): name of the PF
+        num_vfs (int):      number of VFs to create under PF
+        timout (int):       times to check for VFs (default 10)
+    
+    Raises:
+        Exception:  failed to create VFs before timeout exceeded
+    """
+    clear_vfs = f"echo 0 > /sys/class/net/{pf_interface}/device/sriov_numvfs"
+    print(clear_vfs)
+    ssh_obj.execute(clear_vfs, 60)
+    create_vfs = f"echo {num_vfs} > /sys/class/net/{pf_interface}/device/sriov_numvfs"
+    print(create_vfs)
+    ssh_obj.execute(create_vfs, 60)
+    if not vfs_created(ssh_obj, pf_interface, num_vfs, timeout):
+        raise Exception(f"Failed to create {num_vfs} VFs on {pf_interface}")
+
 def no_zero_macs_pf(ssh_obj, pf_interface, timeout = 10):
     """ Check that none of the pf_interface VFs have all zero MAC addresses (from the pf report)
 

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -20,15 +20,14 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
     dut_ip = testdata['dut_ip']
     vf0_mac = testdata['dut_mac']
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
-    steps = [
-        "echo 0 > /sys/class/net/{}/device/sriov_numvfs".format(pf),
-        "echo 1 > /sys/class/net/{}/device/sriov_numvfs".format(pf),
-        "ip link set {} vf 0 mac {}".format(pf, vf0_mac),      
-        ]
-    for step in steps:
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-    
+
+    create_vfs(dut, pf, 1)
+
+    cmd = "ip link set {} vf 0 mac {}".format(pf, vf0_mac)
+    print(cmd)
+    code, out, err = dut.execute(cmd)
+    assert code == 0, err
+
     vf_pci = get_pci_address(dut, pf+"v0")
     assert bind_driver(dut, vf_pci, "vfio-pci")
     


### PR DESCRIPTION
This case was consistently failing before the fix with RHEL8.6 and RT kernel. 
It is passed in multiple runs after this fix:

```
SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py::test_SR_IOV_macAddress_DPDK PASSED                                                                                                        [100%]

========================================================================================== 1 passed in 10.00s ==========================================================================================
(venv) [akiselev@localhost tests]$ pytest -v SR_IOV_macAddress_DPDK
========================================================================================= test session starts ==========================================================================================
platform linux -- Python 3.10.5, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/akiselev/intel-sriov-test/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.5', 'Platform': 'Linux-5.18.11-200.fc36.x86_64-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.5', 'py': '1.11.0', 'pluggy': '1.0.0'}, 'Plugins': {'html': '3.1.1', 'metadata': '2.0.1'}, 'JAVA_HOME': '/usr/java/latest', 'DUT Kernel': '4.18.0-372.16.1.rt7.173.el8_6.x86_64', 'NIC Driver': 'ice\n 1.9.0_rc61\n', 'NIC Firmware': '4.00', 'IAVF Driver': '4.5.0_rc23'}
rootdir: /home/akiselev/intel-sriov-test/sriov/tests
plugins: html-3.1.1, metadata-2.0.1
collected 1 item                                                                                                                                                                                       

SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py::test_SR_IOV_macAddress_DPDK PASSED                                                                                                        [100%]

========================================================================================== 1 passed in 10.14s ==========================================================================================
(venv) [akiselev@localhost tests]$ pytest -v SR_IOV_macAddress_DPDK
========================================================================================= test session starts ==========================================================================================
platform linux -- Python 3.10.5, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/akiselev/intel-sriov-test/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.5', 'Platform': 'Linux-5.18.11-200.fc36.x86_64-x86_64-with-glibc2.35', 'Packages': {'pytest': '6.2.5', 'py': '1.11.0', 'pluggy': '1.0.0'}, 'Plugins': {'html': '3.1.1', 'metadata': '2.0.1'}, 'JAVA_HOME': '/usr/java/latest', 'DUT Kernel': '4.18.0-372.16.1.rt7.173.el8_6.x86_64', 'NIC Driver': 'ice\n 1.9.0_rc61\n', 'NIC Firmware': '4.00', 'IAVF Driver': '4.5.0_rc23'}
rootdir: /home/akiselev/intel-sriov-test/sriov/tests
plugins: html-3.1.1, metadata-2.0.1
collected 1 item                                                                                                                                                                                       

SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py::test_SR_IOV_macAddress_DPDK PASSED                                                                                                        [100%]

========================================================================================== 1 passed in 10.06s ==========================================================================================
(venv) [akiselev@localhost tests]$ 
 
```