### PR TITLE
Hotfix for vf creation checks

### DIFF
--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -223,9 +223,9 @@ def vfs_created(ssh_obj, pf_interface, num_vfs, timeout = 10):
     cmd = "ls -d /sys/class/net/" + pf_interface + "v* | wc -w"
     print(cmd)
     for i in range(timeout):
+        time.sleep(1)
         code, out, err = ssh_obj.execute(cmd)
         if code != 0:
-            time.sleep(1)
             continue
         if int(out[0].strip()) == num_vfs:
             return True


### PR DESCRIPTION
There is a bug where the timeout in the util to check VF creation will run quicker because of the placement of sleep and continue. The sleep has been moved to the start of the loop to aleviate this and fit the structure of the other functions. This should be merged as soon as it is reviewed because it is a fix.