### PR TITLE
Use common functions to set and verify VF address

### DIFF
--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -191,7 +191,7 @@ def get_vf_mac(ssh_obj, intf, vf_id):
     Args:
         ssh_obj (_type_): SSH connection obj
         intf (str):       interface name
-        vf_id (str):      virtual function ID
+        vf_id (int):      virtual function ID
 
     Raises:
         Exception:  command failure
@@ -207,6 +207,60 @@ def get_vf_mac(ssh_obj, intf, vf_id):
             return line.strip("\n")
     raise ValueError("can't parse mac address")
 
+def set_vf_mac(ssh_obj, intf, vf_id, address, timeout = 10, interval = 0.1):
+    """ Set the VF mac address
+    
+    Args:
+        ssh_obj (_type_): SSH connection obj
+        intf (str):       interface name
+        vf_id (int):      virtual function ID
+        address(str):     mac address
+        timeout(int):     number of seconds to timeout
+        
+    Returns:
+        True: mac address is set with success
+        False: mac address can't be set before timeout
+    """
+    set_mac_cmd = f"ip link set {intf} vf {vf_id} mac {address}"
+    print(set_mac_cmd)
+    code, out, err = ssh_obj.execute(set_mac_cmd)
+    if code != 0:
+        return False 
+
+    count = int(timeout/interval) + 1
+    while count > 0:
+        vf_mac = get_intf_mac(ssh_obj, f"{intf}v{vf_id}")
+        if vf_mac == address:
+            return True
+        count -= 1
+        time.sleep(interval)    
+    return False
+
+def verify_vf_address(ssh_obj, intf, vf_id, address, timeout = 10, interval = 0.1):
+    """ verify that the VF has the specified address
+    
+    Args:
+        ssh_obj (_type_): SSH connection obj
+        intf (str):       interface name
+        vf_id (int):      virtual function ID
+        address(str):     mac address
+        timeout(int):     number of seconds to timeout
+        interval(float):  polling interval in seconds
+        
+    Returns:
+        True: The VF has the specified address
+        False: The VF doesn't have the specified address before timeout
+    """
+    count = int(timeout/interval) + 1
+    while count > 0:
+        vf_mac = get_vf_mac(ssh_obj, intf, vf_id)
+        print(vf_mac)
+        if vf_mac == address:
+            return True
+        timeout -= 1
+        time.sleep(interval)
+    return False
+  
 def vfs_created(ssh_obj, pf_interface, num_vfs, timeout = 10):
     """ Check that the num_vfs of pf_interface are created before timeout
     
@@ -249,8 +303,7 @@ def create_vfs(ssh_obj, pf_interface, num_vfs, timeout = 10):
     create_vfs = f"echo {num_vfs} > /sys/class/net/{pf_interface}/device/sriov_numvfs"
     print(create_vfs)
     ssh_obj.execute(create_vfs, 60)
-    if not vfs_created(ssh_obj, pf_interface, num_vfs, timeout):
-        raise Exception(f"Failed to create {num_vfs} VFs on {pf_interface}")
+    return vfs_created(ssh_obj, pf_interface, num_vfs, timeout)
 
 def no_zero_macs_pf(ssh_obj, pf_interface, timeout = 10):
     """ Check that none of the pf_interface VFs have all zero MAC addresses (from the pf report)

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -216,6 +216,7 @@ def set_vf_mac(ssh_obj, intf, vf_id, address, timeout = 10, interval = 0.1):
         vf_id (int):      virtual function ID
         address(str):     mac address
         timeout(int):     number of seconds to timeout
+        interval(float):  polling interval in seconds
         
     Returns:
         True: mac address is set with success

--- a/sriov/tests/SR_IOV_InterVF_DPDK/test_SR_IOV_InterVF_DPDK.py
+++ b/sriov/tests/SR_IOV_InterVF_DPDK/test_SR_IOV_InterVF_DPDK.py
@@ -34,7 +34,7 @@ def test_SR_IOV_InterVF_DPDK(dut, settings, testdata, spoof,
     mac_prefix = "aa:bb:cc:dd:ee:0"
     ip_prefix = "100.1.1.1"
 
-    create_vfs(dut, pf, 2)
+    assert create_vfs(dut, pf, 2)
 
     steps = [] 
     for i in range(2):

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -21,7 +21,7 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
     vf0_mac = testdata['dut_mac']
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
 
-    create_vfs(dut, pf, 1)
+    assert create_vfs(dut, pf, 1)
 
     cmd = "ip link set {} vf 0 mac {}".format(pf, vf0_mac)
     print(cmd)


### PR DESCRIPTION
The original script creates a small shell script and run that shell script on the target machine to work around timing issue due to 1) VF not get created quick enough 2) mac address not set quick enough.

The above trick of using a shell script on the target machine works fine and does solve the timing issue at the beginning of automation development. Now we would like to improve the test script readability by using common util functions to create VF functions and set VF MAC address.