### PR TITLE
Hot fix: SR_IOV_MTU ping timing issue

### DIFF
--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -258,7 +258,7 @@ def verify_vf_address(ssh_obj, intf, vf_id, address, timeout = 10, interval = 0.
         print(vf_mac)
         if vf_mac == address:
             return True
-        timeout -= 1
+        count -= 1
         time.sleep(interval)
     return False
   
@@ -400,3 +400,24 @@ def execute_and_assert(ssh_obj, cmds, exit_code, timeout=0):
         assert code == exit_code
         time.sleep(timeout)
     return outs, errs
+
+def execute_until_timeout(ssh_obj, cmd, timeout=10):
+    """ Execute cmd and check for 0 exit code until timeout
+
+    Args:
+        ssh_obj:         ssh connection obj
+        cmd (str):       a single command to run
+        timeout (int):   optional timeout between cmds (default 10)
+
+    Returns:
+        True: cmd return exit code 0 before timeout
+        False: cmd does not return exit code 0
+    """
+    count = max(1, int(timeout))
+    while count > 0:
+        code, out, err = ssh_obj.execute(cmd)
+        if code == 0:
+            return True
+        count -= 1
+        time.sleep(1)
+    return False

--- a/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
+++ b/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
@@ -78,7 +78,7 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
 
     ping_cmd = f"ping -W 1 -c 1 -s {mtu-28} -M do {trafficgen_ip}"
     print(ping_cmd)
-    code, out, err = dut.execute(ping_cmd)
+    ping_result = execute_until_timeout(dut, ping_cmd)
 
     # recover the system before the final assert
     rm_arp_entry(trafficgen, dut_ip)
@@ -88,4 +88,4 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     dut.execute(f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs")
     dut.execute(f"ip link set {pf} mtu 1500")
     
-    assert code == 0, err
+    assert ping_result


### PR DESCRIPTION
==================================== test session starts =====================================
platform linux -- Python 3.6.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.7', 'Platform': 'Linux-3.10.0-1160.66.1.el7.x86_64-x86_64-with-redhat-7.9-Maipo', 'Packages': {'pytest': '6.2.5', 'py': '1.11.0', 'pluggy': '1.0.0'}, 'Plugins': {'html': '3.1.1', 'metadata': '1.11.0'}, 'DUT Kernel': '4.18.0-305.58.1.rt7.130.el8_4.x86_64', 'NIC Driver': 'ice\n 4.18.0-305.58.1.rt7.130.el8_4.x\n', 'NIC Firmware': '2.10', 'IAVF Driver': '4.18.0-305.58.1.rt7.130.el8_4.x86_64'}
rootdir: /home/jianzzha/intel-sriov-test/sriov/tests
plugins: html-3.1.1, metadata-1.11.0
collected 1 item                                                                             

SR_IOV_MTU/test_SR_IOV_MTU.py::test_SR_IOV_MTU PASSED                                  [100%]

===================================== 1 passed in 10.96s =====================================