### PR TITLE
Refactor remaining tests

### DIFF
--- a/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
+++ b/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
@@ -16,23 +16,14 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
 
     dut_ip = testdata['dut_ip']
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
-    steps = [
-        f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs",
-        f"echo 1 > /sys/class/net/{pf}/device/sriov_numvfs",
-    ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(1)
+    
+    assert create_vfs(dut, pf, 1)
 
     # command to get the maxmtu from the DUT
-    cmd = f"ip -d link list {pf}"
-    print(cmd)
-    code, out, err = dut.execute(cmd)
-    assert code == 0
+    cmd = [f"ip -d link list {pf}"]
+    outs, errs = execute_and_assert(dut, cmd, 0)   
     dut_mtu = 0
-    for line in out:
+    for line in outs[0]:
         match = re.search(r'maxmtu (\d+)', line)
         if match is not None:
             dut_mtu = int(match.group(1))
@@ -42,9 +33,9 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     # get trafficgen maxmtu
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_mtu = 0
-    code, out, err = trafficgen.execute(f"ip -d link list {trafficgen_pf}")
-    assert code == 0
-    for line in out:
+    cmd = [f"ip -d link list {trafficgen_pf}"]
+    outs, errs = execute_and_assert(trafficgen, cmd, 0)
+    for line in outs[0]:
         match = re.search(r'maxmtu (\d+)', line)
         if match is not None:
             trafficgen_mtu = int(match.group(1))
@@ -54,18 +45,17 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     # use the smaller mtu between dut and trafficgen
     mtu = min(dut_mtu, trafficgen_mtu)
     
-    trafficgen.execute(f"ip link set {trafficgen_pf} mtu {mtu}")
+    cmd = [f"ip link set {trafficgen_pf} mtu {mtu}"]
+    execute_and_assert(trafficgen, cmd, 0)
+    
     steps = [
         f"ip link set {pf} mtu {mtu}",
         f"ip link set {pf}v0 mtu {mtu}",
         f"ip link set {pf}v0 up",
         f"ip add add {dut_ip}/24 dev {pf}v0"
     ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(0.1)
+    
+    execute_and_assert(dut, steps, 0, 0.1)
 
     vf0_mac = get_vf_mac(dut, pf, 0)
     trafficgen_ip = testdata['trafficgen_ip']
@@ -75,7 +65,9 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip)
     add_arp_entry(trafficgen, dut_ip, vf0_mac)
     add_arp_entry(dut, trafficgen_ip, trafficgen_mac)
-
+    
+    # Special case: ARP entries may not be populated before first ping, 
+    # so we wait and execute the ping multiple times if needed
     ping_cmd = f"ping -W 1 -c 1 -s {mtu-28} -M do {trafficgen_ip}"
     print(ping_cmd)
     ping_result = execute_until_timeout(dut, ping_cmd)
@@ -84,8 +76,10 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     rm_arp_entry(trafficgen, dut_ip)
     clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
     rm_arp_entry(dut, trafficgen_ip)
-    trafficgen.execute(f"ip link set {trafficgen_pf} mtu 1500")
-    dut.execute(f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs")
-    dut.execute(f"ip link set {pf} mtu 1500")
+    cmd = [f"ip link set {trafficgen_pf} mtu 1500"]
+    execute_and_assert(trafficgen, cmd, 0)
+    cmds = [f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs",
+            f"ip link set {pf} mtu 1500"]
+    execute_and_assert(dut, cmds, 0)
     
     assert ping_result

--- a/sriov/tests/SR_IOV_MultipleVFCreation_withMTU/test_SR_IOV_MultipleVFCreation_withMTU.py
+++ b/sriov/tests/SR_IOV_MultipleVFCreation_withMTU/test_SR_IOV_MultipleVFCreation_withMTU.py
@@ -19,12 +19,8 @@ def test_SRIOVMultipleVFCreationwithMTU(dut, settings, testdata, execution_numbe
     max_vfs_cmd = ["cat " + testdata['pf_net_paths'][pf] + "/sriov_totalvfs"]
     outs, errs = execute_and_assert(dut, max_vfs_cmd, 0)
     max_vfs = outs[0][0].strip()
-
-    set_vfs = ["echo " + max_vfs + " > " + testdata['pf_net_paths'][pf] + "/sriov_numvfs"]
-    execute_and_assert(dut, set_vfs, 0)
-
-    check_vfs_created = vfs_created(dut, testdata['pfs'][pf]['name'], int(max_vfs))
-    assert check_vfs_created == True
+    
+    assert create_vfs(dut, testdata['pfs'][pf]['name'], int(max_vfs))
 
     check_no_zero_macs_pf = no_zero_macs_pf(dut, testdata['pfs'][pf]['name'])
     assert check_no_zero_macs_pf == True

--- a/sriov/tests/SR_IOV_QinQ/test_SR_IOV_QinQ.py
+++ b/sriov/tests/SR_IOV_QinQ/test_SR_IOV_QinQ.py
@@ -16,27 +16,17 @@ def test_SR_IOV_QinQ(dut, trafficgen, settings, testdata):
     outside_tag = 10
     inside_tag = 20
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
-    steps = [
-        f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs",
-        f"echo 1 > /sys/class/net/{pf}/device/sriov_numvfs",
-    ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(1)
-        
+
+    assert create_vfs(dut, pf, 1)
+
     steps = [
         f"ip link set {pf} vf 0 vlan {outside_tag} proto 802.1ad",
         f"ip link add link {pf}v0 name {pf}v0.{inside_tag} type vlan id {inside_tag}",
         f"ip link set {pf}v0.{inside_tag} up",
         f"ip add add {dut_ip}/24 dev {pf}v0.{inside_tag}",
         ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(0.1)
+    
+    execute_and_assert(dut, steps, 0, 0.1)
 
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_mac = settings.config["trafficgen"]["interface"]["pf1"]["mac"]

--- a/sriov/tests/SR_IOV_Spoof_Mac/test_SR_IOV_Spoof_Mac.py
+++ b/sriov/tests/SR_IOV_Spoof_Mac/test_SR_IOV_Spoof_Mac.py
@@ -17,20 +17,17 @@ def test_SR_IOV_Spoof_Mac(dut, trafficgen, settings, testdata, spoof):
 
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
     steps = [
-        f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs",
-        f"echo 1 > /sys/class/net/{pf}/device/sriov_numvfs",
         f"ip link set {pf}v0 down",
         f"ip link set {pf} vf 0 mac {testdata['dut_mac']}",
         f"ip link set {pf} vf 0 spoof {spoof}",
         f"ip add add {testdata['dut_ip']}/24 dev {pf}v0",
         f"ip link set {pf}v0 up"
         ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(0.1)
-    
+
+    create_vfs(dut, pf, 1)
+
+    execute_and_assert(dut, steps, 0, 0.1)
+
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_mac = settings.config["trafficgen"]["interface"]["pf1"]["mac"]
     spoof_mac = testdata['dut_spoof_mac']

--- a/sriov/tests/SR_IOV_TrustMode/test_SR_IOV_TrustMode.py
+++ b/sriov/tests/SR_IOV_TrustMode/test_SR_IOV_TrustMode.py
@@ -15,34 +15,27 @@ def test_SR_IOV_TrustMode(dut, settings):
     mac_3 = "aa:bb:cc:dd:ee:33"
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
     steps = [
-        "echo 0 > /sys/class/net/{}/device/sriov_numvfs".format(pf),
-        "echo 1 > /sys/class/net/{}/device/sriov_numvfs".format(pf),
         f"ip link set {pf}v0 down",
         f"ip link set {pf} vf 0 mac {mac_1}",
         f"ip link set {pf} vf 0 trust on",
         f"ip link set {pf}v0 address {mac_2}",
         f"ip link set {pf}v0 up"
         ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(0.1)
+    
+    create_vfs(dut, pf, 1)
+    
+    execute_and_assert(dut, steps, 0, 0.1)
 
     # check if vf 0 mac address is equal to mac_2
-    cmd = "ip link show {}".format(pf) + " | awk '/vf 0/{print $4;}'"
-    print(cmd)
-    code, out, err = dut.execute(cmd)
-    assert code == 0, err
-    vf_mac = out[0].strip("\n")
+    cmd = ["ip link show {}".format(pf) + " | awk '/vf 0/{print $4;}'"]
+    outs, errs = execute_and_assert(dut, cmd, 0)
+    vf_mac = outs[0][0].strip("\n")
     print(vf_mac)
     assert vf_mac == mac_2
     
     # set trust mode to off
-    cmd = "ip link set {}".format(pf) + " vf 0 trust off"
-    print(cmd)
-    code, out, err = dut.execute(cmd)
-    assert code == 0, err
+    cmd = ["ip link set {}".format(pf) + " vf 0 trust off"]
+    execute_and_assert(dut, cmd, 0)
     
     # try to overwrite mac_2 with mac_3
     cmd = "ip link set {}".format(pf) + "v0 address {}".format(mac_3)
@@ -52,10 +45,8 @@ def test_SR_IOV_TrustMode(dut, settings):
         print(err[0].strip("\n"))
            
     # check if vf 0 mac address is NOT equal to mac_3
-    cmd = "ip link show {}".format(pf) + " | awk '/vf 0/{print $4;}'"
-    print(cmd)
-    code, out, err = dut.execute(cmd)
-    assert code == 0, err
-    vf_mac = out[0].strip("\n")
+    cmd = ["ip link show {}".format(pf) + " | awk '/vf 0/{print $4;}'"]
+    outs, errs = execute_and_assert(dut, cmd, 0)
+    vf_mac = outs[0][0].strip("\n")
     print(vf_mac)
     assert vf_mac != mac_3    

--- a/sriov/tests/SR_IOV_macAddress/test_SR_IOV_macAddress.py
+++ b/sriov/tests/SR_IOV_macAddress/test_SR_IOV_macAddress.py
@@ -17,27 +17,24 @@ def test_SR_IOV_macAddress(dut, trafficgen, settings, testdata):
     vf0_mac = testdata['dut_mac']
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
     steps = [
-        "echo 0 > /sys/class/net/{}/device/sriov_numvfs".format(pf),
-        "echo 1 > /sys/class/net/{}/device/sriov_numvfs".format(pf),
         "ip link set {}v0 down".format(pf),
         "ip link set {} vf 0 mac {}".format(pf, vf0_mac),
         "ip link set {}v0 up".format(pf),
         "ip add add {}/24 dev {}v0".format(dut_ip, pf) 
         ]
-    for step in steps:
-        print(step)
-        code, out, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(0.1)
+
+    create_vfs(dut, pf, 1)
+
+    execute_and_assert(dut, steps, 0, 0.1)
 
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_vlan = 0
     clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan) 
     config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip)
     add_arp_entry(trafficgen, dut_ip, vf0_mac)
-    code, out, err = trafficgen.execute("ping -W 1 -c 1 {}".format(testdata['dut_ip']))
+    ping_cmd = "ping -W 1 -c 1 {}".format(testdata['dut_ip'])
+    print(ping_cmd)
+    ping_result = execute_until_timeout(trafficgen, ping_cmd)
     rm_arp_entry(trafficgen, trafficgen_ip)
     clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
-    assert code == 0, err
-
-        
+    assert ping_result  

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -23,10 +23,8 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
 
     assert create_vfs(dut, pf, 1)
 
-    cmd = "ip link set {} vf 0 mac {}".format(pf, vf0_mac)
-    print(cmd)
-    code, out, err = dut.execute(cmd)
-    assert code == 0, err
+    cmd = ["ip link set {} vf 0 mac {}".format(pf, vf0_mac)]
+    execute_and_assert(dut, cmd, 0)
 
     vf_pci = get_pci_address(dut, pf+"v0")
     assert bind_driver(dut, vf_pci, "vfio-pci")
@@ -53,11 +51,11 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
     clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan) 
     config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip)
     add_arp_entry(trafficgen, dut_ip, vf0_mac)
-    code, out, err = trafficgen.execute("ping -W 1 -c 1 {}".format(dut_ip))
+    ping_cmd = "ping -W 1 -c 1 {}".format(dut_ip)
+    print(ping_cmd)
+    ping_result = execute_until_timeout(trafficgen, ping_cmd)
     rm_arp_entry(trafficgen, trafficgen_ip)
     clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
     dut.stop_testpmd()
-    assert code == 0, err
-
-
+    assert ping_cmd
         


### PR DESCRIPTION
A PR which implements the execute_and_assert and execute_until_timeout utils for all SR-IOV test cases (except InterVF, InterVF_DPDK and MultipleVFCreation_with_MTU which were in separate PRs). Below are the reports as proof of run:
SR_IOV_macAddress: https://gist.github.com/dkosteck/94b47324729bc8f2659d75c61421c852
SR_IOV_macAddress_DPDK: https://gist.github.com/dkosteck/c75664257d22521c3296bcedfaa4df21
SR_IOV_MTU: https://gist.github.com/dkosteck/420bc5a4e0fe3b46d32c735030e32756
SR_IOV_Permutation: https://gist.github.com/dkosteck/f846b80308f1b0b82854bb0bf8c65f30
SR_IOV_Permutation_DPDK: https://gist.github.com/dkosteck/c0d4bf5d72339a544eea453ac202b07f
SR_IOV_QinQ: Expected not to work, no report
SR_IOV_Spoof_Mac: https://gist.github.com/dkosteck/8515d6d4670986aaf49c1ca45e1f274a
SR_IOV_TrustMode: https://gist.github.com/dkosteck/edb6bbf1a72c471f2311a5c274100df7