### PR TITLE
Removing JSON from report

### DIFF
--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -117,8 +117,6 @@ def _report_extras(extra, request, settings, monkeypatch):
                 test_dir + '/' + settings.config['tests_doc_file']
             extra.append(extras.html('<p>Link to the test specification: <a href="' +
                                      link + '">' + case_name + ' Documentation</a></p>'))
-            extra.append(extras.json(
-                {"test case": case_name, "test dir": os.path.dirname(request.module.__file__)}))
     except:
         return
 


### PR DESCRIPTION
Report showing no links to JSON: https://gist.github.com/dkosteck/0f330fae0d2c7e5b2af44785c78f527b