### PR TITLE
Add cmdline option to stop the test run on failed case

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,14 @@ The common code shared by all test cases is under the `sriov/common`.
 The common code has its own test cases. Majority of the common code test cases are under the `tests/common/` folder. Pytest is used to execute these test cases. Because a valid `config.yaml` file is expected by pytest to establish ssh connections and execute these test cases, they are considered as e2e test.
 
 A small portion of common code test cases are done using mock. These mock unit test cases are under the `sriov/common` folder, along with the common code itself. The purpose of the mock unit tests is to cover senarios that are difficult to cover via the e2e tests.
+
+## Debug Failed Test Case
+
+When a test case is failing, one may want to immediately stop the test run and keep the failed setup for manual debug. This can not be achieved with the pytest `-x` option, as `-x` still allow the clean up to happen. In stead, this can be done by using `--skipclean` option.
+
+For example, if some permutation in `SR_IOV_Permutation_DPDK` has failed, re-run this test case like this,
+```pytest -v --skipclean SR_IOV_Permutation_DPDK```
+
+The test execution will stop immediately without clean up, one can access the DUT and the trafficgen to debug.
+
+After the debug is complete, one has to manually clean up the set up.

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -83,6 +83,7 @@ def clear_interface(ssh_obj, intf, vlan=0):
     Raises:
         Exception: command failure
     """
+    # The virtual interface may not exist, force true to ignore the command failure
     if vlan != 0:
         steps = [
                 f"ip addr flush dev {intf}.{vlan} || true",
@@ -124,11 +125,31 @@ def rm_arp_entry(ssh_obj, ip):
     Raises:
         Exception: command failure
     """
-    cmd = f"arp -d {ip} || true"
+    cmd = f"arp -d {ip} || true"    # not a failure if the ip entry not exist
     code, _, err = ssh_obj.execute(cmd)
     if code != 0:
         raise Exception(err)
+
+def prepare_ping_test(tgen, tgen_intf, tgen_vlan, tgen_ip, tgen_mac, 
+                      dut, dut_ip, dut_mac):
+    """Collection of steps to prepare for ping test
     
+    Args:
+        tgen: trafficgen ssh handler
+        tgen_intf(str): trafficgen physical interface name
+        tgen_vlan(int): vlan ID on the trafficgen physical interface
+        tgen_ip(str): trafficgen ip address
+        tgen_mac(str): trafficgen mac address
+        dut: DUT ssh handler
+        dut_ip: DUT ip address
+        dut_mac: DUT mac address
+    """
+    clear_interface(tgen, tgen_intf, tgen_vlan)
+    config_interface(tgen, tgen_intf, tgen_vlan, tgen_ip)
+    add_arp_entry(tgen, dut_ip, dut_mac)
+    add_arp_entry(dut, tgen_ip, tgen_mac)
+    
+ 
 def start_tmux(ssh_obj, name, cmd):
     """ Run cmd in a tmux session
 

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -136,15 +136,15 @@ def prepare_ping_test(tgen, tgen_intf, tgen_vlan, tgen_ip, tgen_mac,
     """Collection of steps to prepare for ping test
     
     Args:
-        tgen: trafficgen ssh handler
-        tgen_intf(str): trafficgen physical interface name
-        tgen_vlan(int): vlan ID on the trafficgen physical interface
-        tgen_ip(str): trafficgen ip address
-        tgen_mac(str): trafficgen mac address; none will not add arp entry on DUT.
-        dut: DUT ssh handler
-        dut_ip: DUT ip address
-        dut_mac: DUT mac address
-        testdata: testdata object
+        tgen (object): trafficgen ssh handler
+        tgen_intf (str): trafficgen physical interface name
+        tgen_vlan (int): vlan ID on the trafficgen physical interface
+        tgen_ip (str): trafficgen ip address
+        tgen_mac (str): trafficgen mac address; set to None will not add arp entry on DUT
+        dut (object): DUT ssh handler
+        dut_ip (str): DUT ip address
+        dut_mac (str): DUT mac address
+        testdata (object): testdata object
     """
     clear_interface(tgen, tgen_intf, tgen_vlan)
     
@@ -166,9 +166,9 @@ def cleanup_after_ping(tgen, dut, testdata):
     """Collection of steps to cleanup after ping test
     
     Args:
-        tgen: trafficgen ssh handler
-        dut: DUT ssh handler
-        testdata: testdata object
+        tgen (object): trafficgen ssh handler
+        dut (object): DUT ssh handler
+        testdata (object): testdata object
     """
     run = testdata['ping'].get('run', False)
     if run:
@@ -186,13 +186,13 @@ def set_mtu(tgen, tgen_pf, dut, dut_pf, dut_vf, mtu, testdata):
     """set MTU on trafficgen and DUT
 
     Args:
-        tgen (obj): trafficgen ssh connection
+        tgen (object): trafficgen ssh connection
         tgen_pf (str): trafficgen PF
-        dut (obj): DUT ssh connection
+        dut (object): DUT ssh connection
         dut_pf (str): DUT PF
         dut_vf (int): DUT VF id
         mtu (int): MTU size in bytes
-        testdata (obj): testdata object
+        testdata (object): testdata object
     """
     testdata['mtu']['changed'] = True
     testdata['mtu']['tgen_intf'] = tgen_pf
@@ -212,9 +212,9 @@ def reset_mtu(tgen, dut, testdata):
     """reset MTU on trafficgen and DUT
 
     Args:
-        tgen (obj): trafficgen ssh connection
-        dut (obj): DUT ssh connection
-        testdata (obj): testdata object
+        tgen (object): trafficgen ssh connection
+        dut (object): DUT ssh connection
+        testdata (object): testdata object
     """
     changed = testdata['mtu'].get('changed', False)
     if changed:

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -149,7 +149,22 @@ def prepare_ping_test(tgen, tgen_intf, tgen_vlan, tgen_ip, tgen_mac,
     add_arp_entry(tgen, dut_ip, dut_mac)
     add_arp_entry(dut, tgen_ip, tgen_mac)
     
- 
+def cleanup_after_ping(tgen, tgen_intf, tgen_vlan, tgen_ip,
+                       dut, dut_ip):
+    """Collection of steps to cleanup after ping test
+    
+    Args:
+        tgen: trafficgen ssh handler
+        tgen_intf(str): trafficgen physical interface name
+        tgen_vlan(int): vlan ID on the trafficgen physical interface
+        tgen_ip(str): trafficgen ip address
+        dut: DUT ssh handler
+        dut_ip: DUT ip address
+    """
+    rm_arp_entry(tgen, dut_ip)
+    clear_interface(tgen, tgen_intf, tgen_vlan)
+    rm_arp_entry(dut, tgen_ip)
+    
 def start_tmux(ssh_obj, name, cmd):
     """ Run cmd in a tmux session
 

--- a/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
+++ b/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
@@ -61,13 +61,10 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     trafficgen_ip = testdata['trafficgen_ip']
     trafficgen_mac = settings.config["trafficgen"]["interface"]["pf1"]["mac"]
     trafficgen_vlan = 0
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
-    config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip)
-    add_arp_entry(trafficgen, dut_ip, vf0_mac)
-    add_arp_entry(dut, trafficgen_ip, trafficgen_mac)
-    
-    # Special case: ARP entries may not be populated before first ping, 
-    # so we wait and execute the ping multiple times if needed
+    prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
+                      trafficgen_ip, trafficgen_mac,
+                      dut, dut_ip, vf0_mac)
+
     ping_cmd = f"ping -W 1 -c 1 -s {mtu-28} -M do {trafficgen_ip}"
     print(ping_cmd)
     ping_result = execute_until_timeout(dut, ping_cmd)

--- a/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
+++ b/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
@@ -70,13 +70,11 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     ping_result = execute_until_timeout(dut, ping_cmd)
 
     # recover the system before the final assert
-    rm_arp_entry(trafficgen, dut_ip)
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
-    rm_arp_entry(dut, trafficgen_ip)
-    cmd = [f"ip link set {trafficgen_pf} mtu 1500"]
-    execute_and_assert(trafficgen, cmd, 0)
-    cmds = [f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs",
-            f"ip link set {pf} mtu 1500"]
-    execute_and_assert(dut, cmds, 0)
+    cleanup_after_ping(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip,
+                       dut, dut_ip)
+
+    trafficgen.execute(f"ip link set {trafficgen_pf} mtu 1500")
+    dut.execute(f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs")
+    dut.execute(f"ip link set {pf} mtu 1500")
     
     assert ping_result

--- a/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
+++ b/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
@@ -16,9 +16,9 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
 
     dut_ip = testdata['dut_ip']
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
-    
-    assert create_vfs(dut, pf, 1)
 
+    assert create_vfs(dut, pf, 1)
+    
     # command to get the maxmtu from the DUT
     cmd = [f"ip -d link list {pf}"]
     outs, errs = execute_and_assert(dut, cmd, 0)   
@@ -45,36 +45,23 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     # use the smaller mtu between dut and trafficgen
     mtu = min(dut_mtu, trafficgen_mtu)
     
-    cmd = [f"ip link set {trafficgen_pf} mtu {mtu}"]
-    execute_and_assert(trafficgen, cmd, 0)
-    
+    set_mtu(trafficgen, trafficgen_pf, dut, pf, 0, mtu, testdata)
+
     steps = [
-        f"ip link set {pf} mtu {mtu}",
-        f"ip link set {pf}v0 mtu {mtu}",
         f"ip link set {pf}v0 up",
         f"ip add add {dut_ip}/24 dev {pf}v0"
     ]
-    
     execute_and_assert(dut, steps, 0, 0.1)
-
+    
     vf0_mac = get_vf_mac(dut, pf, 0)
     trafficgen_ip = testdata['trafficgen_ip']
     trafficgen_mac = settings.config["trafficgen"]["interface"]["pf1"]["mac"]
     trafficgen_vlan = 0
     prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
                       trafficgen_ip, trafficgen_mac,
-                      dut, dut_ip, vf0_mac)
+                      dut, dut_ip, vf0_mac,
+                      testdata)
 
     ping_cmd = f"ping -W 1 -c 1 -s {mtu-28} -M do {trafficgen_ip}"
     print(ping_cmd)
-    ping_result = execute_until_timeout(dut, ping_cmd)
-
-    # recover the system before the final assert
-    cleanup_after_ping(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip,
-                       dut, dut_ip)
-
-    trafficgen.execute(f"ip link set {trafficgen_pf} mtu 1500")
-    dut.execute(f"echo 0 > /sys/class/net/{pf}/device/sriov_numvfs")
-    dut.execute(f"ip link set {pf} mtu 1500")
-    
-    assert ping_result
+    assert execute_until_timeout(dut, ping_cmd)

--- a/sriov/tests/SR_IOV_Permutation/test_SR_IOV_Permutation.py
+++ b/sriov/tests/SR_IOV_Permutation/test_SR_IOV_Permutation.py
@@ -46,13 +46,14 @@ def test_SR_IOV_Permutation(dut, trafficgen, settings, testdata, spoof,
     
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_vlan = testdata['vlan'] if vlan else 0
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan) 
-    config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, testdata['trafficgen_ip'])
-    add_arp_entry(trafficgen, testdata['dut_ip'], testdata['dut_mac'])
-    cmd = "ping -W 1 -c 1 {}".format(testdata['dut_ip'])
-    print(cmd)
-    ping_result = execute_until_timeout(trafficgen, cmd)
-    rm_arp_entry(trafficgen, testdata['trafficgen_ip'])
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
-
-    assert ping_result
+    trafficgen_ip = testdata['trafficgen_ip']
+    trafficgen_mac = None   #None means no need to add arp entry on DUT
+    dut_ip = testdata['dut_ip']
+    vf0_mac = testdata['dut_mac']
+    prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
+                      trafficgen_ip, trafficgen_mac,
+                      dut, dut_ip, vf0_mac,
+                      testdata)
+    assert execute_until_timeout(trafficgen, f"ping -W 1 -c 1 {dut_ip}")
+    
+    

--- a/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
+++ b/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
@@ -66,13 +66,13 @@ def test_SR_IOV_Permutation_DPDK(dut, trafficgen, settings, testdata, spoof,
         assert code == 0
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_vlan = testdata['vlan'] if vlan else 0
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan) 
-    config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, testdata['trafficgen_ip'])
-    add_arp_entry(trafficgen, testdata['dut_ip'], testdata['dut_mac'])
-    ping_cmd = "ping -W 1 -c 1 {}".format(testdata['dut_ip'])
-    print(ping_cmd)
-    ping_result = execute_until_timeout(trafficgen, ping_cmd)
-    rm_arp_entry(trafficgen, testdata['trafficgen_ip'])
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
-    assert ping_result
-    
+    trafficgen_ip = testdata['trafficgen_ip']
+    trafficgen_mac = None   #None means no need to add arp entry on DUT
+    dut_ip = testdata['dut_ip']
+    vf0_mac = testdata['dut_mac']
+    prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
+                      trafficgen_ip, trafficgen_mac,
+                      dut, dut_ip, vf0_mac,
+                      testdata)
+    assert execute_until_timeout(trafficgen, f"ping -W 1 -c 1 {dut_ip}")
+

--- a/sriov/tests/SR_IOV_macAddress/test_SR_IOV_macAddress.py
+++ b/sriov/tests/SR_IOV_macAddress/test_SR_IOV_macAddress.py
@@ -28,13 +28,16 @@ def test_SR_IOV_macAddress(dut, trafficgen, settings, testdata):
     execute_and_assert(dut, steps, 0, 0.1)
 
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
+    trafficgen_mac = settings.config["trafficgen"]["interface"]["pf1"]["mac"]
     trafficgen_vlan = 0
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan) 
-    config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip)
-    add_arp_entry(trafficgen, dut_ip, vf0_mac)
+    prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
+                      trafficgen_ip, trafficgen_mac,
+                      dut, dut_ip, vf0_mac,
+                      testdata)
+    
     ping_cmd = "ping -W 1 -c 1 {}".format(testdata['dut_ip'])
     print(ping_cmd)
-    ping_result = execute_until_timeout(trafficgen, ping_cmd)
-    rm_arp_entry(trafficgen, trafficgen_ip)
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
-    assert ping_result  
+    assert execute_until_timeout(trafficgen, ping_cmd)
+
+
+        

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -47,15 +47,14 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
         code = dut.testpmd_cmd(step)
         assert code == 0
 
-    trafficgen_vlan = 0    
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan) 
-    config_interface(trafficgen, trafficgen_pf, trafficgen_vlan, trafficgen_ip)
-    add_arp_entry(trafficgen, dut_ip, vf0_mac)
-    ping_cmd = "ping -W 1 -c 1 {}".format(dut_ip)
-    print(ping_cmd)
-    ping_result = execute_until_timeout(trafficgen, ping_cmd)
-    rm_arp_entry(trafficgen, trafficgen_ip)
-    clear_interface(trafficgen, trafficgen_pf, trafficgen_vlan)
-    dut.stop_testpmd()
-    assert ping_cmd
+    trafficgen_vlan = 0
+    trafficgen_mac = None   #None means no need to set arp entry on DUT
+    prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
+                      trafficgen_ip, trafficgen_mac,
+                      dut, dut_ip, vf0_mac,
+                      testdata)   
+    
+    assert execute_until_timeout(trafficgen, "ping -W 1 -c 1 {}".format(dut_ip))
+
+
         

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -54,7 +54,9 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
                       dut, dut_ip, vf0_mac,
                       testdata)   
     
-    assert execute_until_timeout(trafficgen, "ping -W 1 -c 1 {}".format(dut_ip))
+    ping_cmd = "ping -W 1 -c 1 {}".format(dut_ip)
+    print(ping_cmd)
+    assert execute_until_timeout(trafficgen, ping_cmd)
 
 
         


### PR DESCRIPTION
When a test case fails, very often we want to stop the test run immediately and debug the system under the failed condition. This PR will add a cmdline option "--skipclean" for this purpose.

Some test case implementation needs update to to support this. In order to "guarantee" cleanup, certain test cases do cleanup before assert. For example, reset the MTU size, delete the ip address/arp entry during ping test. A better way to "guarantee" such cleanup is to move the cleanup from individual test cases to conftest.

This PR changed several things:
1. in utils.py, create a common ping prepare function; and use this common function to replace the steps in each individual test case
2. in utils.py, create  a common set_mtu function; and use this common function to replace the set mtu operation in each individual test case
3. in utils.py, create a common function to cleanup after ping; use this common function in conftest; remove the corresponding clean up steps from individual test cases
4. in utils.py, create a common reset mtu function; use this common function in conftest; remove the corresponding reset mtu steps from individual test cases
5. add "--skipclean" option in conftest
6. updated testdata object to track the ping clean up data and the reset mtu data; this way the cleanup or reset mtu only happen when necessary.