### PR TITLE
Refactor InterVF and macAddress cases to pass linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,3 +22,7 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 $(git ls-files 'sriov/common/*.py') --count --ignore=E203 --max-complexity=15 --max-line-length=88 --show-source --statistics
+        flake8 $(git ls-files 'sriov/tests/SR_IOV_macAddress_DPDK/*.py') --count --ignore=E203 --max-complexity=15 --max-line-length=88 --show-source --statistics
+        flake8 $(git ls-files 'sriov/tests/SR_IOV_macAddress/*.py') --count --ignore=E203 --max-complexity=15 --max-line-length=88 --show-source --statistics
+        flake8 $(git ls-files 'sriov/tests/SR_IOV_InterVF_DPDK/*.py') --count --ignore=E203 --max-complexity=15 --max-line-length=88 --show-source --statistics
+        flake8 $(git ls-files 'sriov/tests/SR_IOV_InterVF/*.py') --count --ignore=E203 --max-complexity=15 --max-line-length=88 --show-source --statistics

--- a/sriov/tests/SR_IOV_InterVF/test_SR_IOV_InterVF.py
+++ b/sriov/tests/SR_IOV_InterVF/test_SR_IOV_InterVF.py
@@ -1,6 +1,5 @@
 import pytest
-import time
-from sriov.common.utils import *
+from sriov.common.utils import create_vfs, execute_and_assert
 
 
 @pytest.mark.parametrize('spoof', ("on", "off"))
@@ -8,9 +7,10 @@ from sriov.common.utils import *
 @pytest.mark.parametrize('qos', (True, False))
 @pytest.mark.parametrize('vlan', (True, False))
 @pytest.mark.parametrize('max_tx_rate', (True, False))
-def test_SR_IOV_InterVF(dut, trafficgen, settings, testdata, spoof,
-                        trust, qos, vlan, max_tx_rate):
-    """ Test and ensure that VFs on the same PF can communicate with each other
+def test_SR_IOV_InterVF(
+    dut, trafficgen, settings, testdata, spoof, trust, qos, vlan, max_tx_rate
+):
+    """Test and ensure that VFs on the same PF can communicate with each other
 
     Args:
         dut:         ssh connection obj
@@ -30,30 +30,35 @@ def test_SR_IOV_InterVF(dut, trafficgen, settings, testdata, spoof,
 
     steps = []
     for i in range(2):
-        steps.extend([
-            f"ip netns add ns{i}",
-            f"ip link set {pf} vf {i} mac {mac_prefix}{i}",
-            f"ip link set {pf} vf {i} spoof {spoof}",
-            f"ip link set {pf} vf {i} trust {trust}",
-        ])
+        steps.extend(
+            [
+                f"ip netns add ns{i}",
+                f"ip link set {pf} vf {i} mac {mac_prefix}{i}",
+                f"ip link set {pf} vf {i} spoof {spoof}",
+                f"ip link set {pf} vf {i} trust {trust}",
+            ]
+        )
         if vlan:
             qos_str = f"qos {testdata['qos']}" if qos else ""
-            steps.append(
-                f"ip link set {pf} vf {i} vlan {testdata['vlan']} {qos_str}")
+            steps.append(f"ip link set {pf} vf {i} vlan {testdata['vlan']} {qos_str}")
         if max_tx_rate:
             steps.append(
-                f"ip link set {pf} vf {i} max_tx_rate {testdata['max_tx_rate']}")
+                f"ip link set {pf} vf {i} max_tx_rate {testdata['max_tx_rate']}"
+            )
         steps.append(f"ip link set {pf}v{i} netns ns{i}")
         steps.append(
-            f"ip netns exec ns{i} ip addr add {ip_addr_prefix}{i}/24 dev {pf}v{i}")
+            f"ip netns exec ns{i} ip addr add {ip_addr_prefix}{i}/24 dev {pf}v{i}"
+        )
         steps.append(f"ip netns exec ns{i} ip link set {pf}v{i} up")
 
     assert create_vfs(dut, pf, 2)
     execute_and_assert(dut, steps, 0, 0.1)
 
-    steps = [f"ip netns exec ns0 arp -s {ip_addr_prefix}1 {mac_prefix}1",
-             f"ip netns exec ns1 arp -s {ip_addr_prefix}0 {mac_prefix}0",
-             f"ip netns exec ns0 ping -W 1 -c 1 {ip_addr_prefix}1",
-             "ip netns del ns0",
-             "ip netns del ns1"]
+    steps = [
+        f"ip netns exec ns0 arp -s {ip_addr_prefix}1 {mac_prefix}1",
+        f"ip netns exec ns1 arp -s {ip_addr_prefix}0 {mac_prefix}0",
+        f"ip netns exec ns0 ping -W 1 -c 1 {ip_addr_prefix}1",
+        "ip netns del ns0",
+        "ip netns del ns1",
+    ]
     execute_and_assert(dut, steps, 0)

--- a/sriov/tests/SR_IOV_InterVF_DPDK/test_SR_IOV_InterVF_DPDK.py
+++ b/sriov/tests/SR_IOV_InterVF_DPDK/test_SR_IOV_InterVF_DPDK.py
@@ -24,7 +24,8 @@ def stop_testpmd_in_tmux(dut, tmux_session):
 def test_SR_IOV_InterVF_DPDK(
     dut, settings, testdata, spoof, trust, qos, vlan, max_tx_rate
 ):
-    """Test and ensure that VFs bound to DPDK driver can communicate with VF on the same PF
+    """Test and ensure that VFs bound to DPDK driver can communicate with VF
+       on the same PF
 
     Args:
         dut:         ssh connection obj

--- a/sriov/tests/SR_IOV_macAddress/test_SR_IOV_macAddress.py
+++ b/sriov/tests/SR_IOV_macAddress/test_SR_IOV_macAddress.py
@@ -1,8 +1,13 @@
-import time
-from sriov.common.utils import *
+from sriov.common.utils import (
+    create_vfs,
+    execute_and_assert,
+    prepare_ping_test,
+    execute_until_timeout,
+)
+
 
 def test_SR_IOV_macAddress(dut, trafficgen, settings, testdata):
-    """ Test and ensure that VF MAC address functions as intended
+    """Test and ensure that VF MAC address functions as intended
 
     Args:
         dut:         ssh connection obj
@@ -19,8 +24,8 @@ def test_SR_IOV_macAddress(dut, trafficgen, settings, testdata):
         "ip link set {}v0 down".format(pf),
         "ip link set {} vf 0 mac {}".format(pf, vf0_mac),
         "ip link set {}v0 up".format(pf),
-        "ip add add {}/24 dev {}v0".format(dut_ip, pf) 
-        ]
+        "ip add add {}/24 dev {}v0".format(dut_ip, pf),
+    ]
 
     create_vfs(dut, pf, 1)
 
@@ -29,14 +34,18 @@ def test_SR_IOV_macAddress(dut, trafficgen, settings, testdata):
     trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_mac = settings.config["trafficgen"]["interface"]["pf1"]["mac"]
     trafficgen_vlan = 0
-    prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
-                      trafficgen_ip, trafficgen_mac,
-                      dut, dut_ip, vf0_mac,
-                      testdata)
-    
+    prepare_ping_test(
+        trafficgen,
+        trafficgen_pf,
+        trafficgen_vlan,
+        trafficgen_ip,
+        trafficgen_mac,
+        dut,
+        dut_ip,
+        vf0_mac,
+        testdata,
+    )
+
     ping_cmd = "ping -W 1 -c 1 {}".format(testdata['dut_ip'])
     print(ping_cmd)
     assert execute_until_timeout(trafficgen, ping_cmd)
-
-
-        

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -9,7 +9,8 @@ from sriov.common.utils import (
 
 
 def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
-    """Test and ensure that VF MAC address functions as intended when bound to DPDK driver
+    """Test and ensure that VF MAC address functions as intended when bound
+       to DPDK driver
 
     Args:
         dut:         ssh connection obj

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -1,11 +1,15 @@
-import pytest
-import logging
-from sriov.common.exec import ShellHandler
-from sriov.common.utils import *
+from sriov.common.utils import (
+    create_vfs,
+    get_pci_address,
+    execute_and_assert,
+    bind_driver,
+    prepare_ping_test,
+    execute_until_timeout,
+)
 
 
 def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
-    """ Test and ensure that VF MAC address functions as intended when bound to DPDK driver
+    """Test and ensure that VF MAC address functions as intended when bound to DPDK driver
 
     Args:
         dut:         ssh connection obj
@@ -25,37 +29,40 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
     cmd = ["ip link set {} vf 0 mac {}".format(pf, vf0_mac)]
     execute_and_assert(dut, cmd, 0)
 
-    vf_pci = get_pci_address(dut, pf+"v0")
+    vf_pci = get_pci_address(dut, pf + "v0")
     assert bind_driver(dut, vf_pci, "vfio-pci")
-    
+
     dpdk_img = settings.config["dpdk_img"]
     cpus = settings.config["dut"]["pmd_cpus"]
-    podman_cmd = "podman run -it --rm --privileged "\
-                 "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "\
-                 "--cpuset-cpus {} {} dpdk-testpmd -l {} -n 4 -a {} "\
-                 "-- --nb-cores=2 -i".format(cpus, dpdk_img, cpus, vf_pci)
+    podman_cmd = (
+        "podman run -it --rm --privileged "
+        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
+        "--cpuset-cpus {} {} dpdk-testpmd -l {} -n 4 -a {} "
+        "-- --nb-cores=2 -i".format(cpus, dpdk_img, cpus, vf_pci)
+    )
     print(podman_cmd)
     dut.start_testpmd(podman_cmd)
     assert dut.testpmd_active()
-    
-    steps = [
-        "set fwd icmpecho",
-        "start"
-        ]
+
+    steps = ["set fwd icmpecho", "start"]
     for step in steps:
         code = dut.testpmd_cmd(step)
         assert code == 0
 
     trafficgen_vlan = 0
-    trafficgen_mac = None   #None means no need to set arp entry on DUT
-    prepare_ping_test(trafficgen, trafficgen_pf, trafficgen_vlan,
-                      trafficgen_ip, trafficgen_mac,
-                      dut, dut_ip, vf0_mac,
-                      testdata)   
-    
+    trafficgen_mac = None  # None means no need to set arp entry on DUT
+    prepare_ping_test(
+        trafficgen,
+        trafficgen_pf,
+        trafficgen_vlan,
+        trafficgen_ip,
+        trafficgen_mac,
+        dut,
+        dut_ip,
+        vf0_mac,
+        testdata,
+    )
+
     ping_cmd = "ping -W 1 -c 1 {}".format(dut_ip)
     print(ping_cmd)
     assert execute_until_timeout(trafficgen, ping_cmd)
-
-
-        


### PR DESCRIPTION
I also added more lines to lint.yaml to cover these new tests. We can consolidate these later once all tests are ready. 