### PR TITLE
Separate testbed info from the config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,9 @@ yum install -y nmap
 
 The test script can be run from a third server. It will set up one ssh session to the TrafficGen and one to the DUT. The script will send commands over the ssh sessions to set up configuration or to send test traffic.
 
-The script will look for `tests/config.yaml` in order to access the TrafficGen and the DUT. Other than the ssh access information, other information such as the interfaces connecting the DUT and the TrafficGen will also be provided in this file. A template `config_template.yaml` is provided as a sample. One can build a local config.yaml from this sample file.
+The script will look for `tests/testbed.yaml` in order to access the TrafficGen and the DUT. Other than the ssh access information, other information such as the interfaces connecting the DUT and the TrafficGen will also be provided in this file. A template `testbed_template.yaml` is provided as a sample. One can build a local testbed.yaml from this sample file. The content of this file is explained below,
 
 ```
-dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"
-github_tests_path:          # URL to the test directory
-                            # example: https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests
-tests_doc_file: 	          # test specification name under the test case directory
-                            # example: "README.md"
-tests_name_field: 	        # name field in the test specification
-                            # example: "Test Case Name:"
 dut:
   host:                     # DUT ip address
   username: root            # need root access
@@ -66,7 +59,19 @@ trafficgen:
       mac: "xx:xx:xx..."    # first PF mac address
 ```
 
-One may also choose to run the test script from the TrafficGen. In that case, the host will be `127.0.0.1`
+If one chooses to run the test script from the TrafficGen, the trafficgen host will be `127.0.0.1`
+
+Besides `tests/testbed.yaml`, the script will also look for `tests/config.yaml`. A template `config_template.yaml` is provided as a sample. In most situations, users can simply copy from this sample file into a local config.yaml. The content of this file is explained below,
+
+```
+dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"  # DPDK build container image
+github_tests_path:          # URL to the test directory
+                            # example: https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests
+tests_doc_file: 	          # test specification name under the test case directory
+                            # example: "README.md"
+tests_name_field: 	        # name field in the test specification
+                            # example: "Test Case Name:"
+```
 
 Running the script from a python3 virtual environment is recommended. Install the required python modules,
 

--- a/sriov/common/config.py
+++ b/sriov/common/config.py
@@ -2,12 +2,17 @@ import yaml
 
 
 class Config:
-    def __init__(self, config_file: str) -> None:
+    def __init__(self, config_file: str, testbed_file: str) -> None:
         """Init the config file object
 
         Args:
             self:
             config_file (str): path to the config file
+            testbed_file (str): path to the testbed file
         """
         with open(config_file, "r") as file:
             self.config = yaml.safe_load(file)
+        with open(testbed_file, "r") as file:
+            testbed = yaml.safe_load(file)
+            for k, v in testbed.items():
+                self.config[k] = v       

--- a/sriov/common/config.py
+++ b/sriov/common/config.py
@@ -15,4 +15,4 @@ class Config:
         with open(testbed_file, "r") as file:
             testbed = yaml.safe_load(file)
             for k, v in testbed.items():
-                self.config[k] = v       
+                self.config[k] = v

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -2,23 +2,4 @@ dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"
 tests_name_field: "Test Case Name:"
 tests_doc_file: "README.md"
 github_tests_path: "https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests"
-dut:
-  host: "DUT ip address"
-  username: root
-  password: "root password"
-  pmd_cpus: "cpu list for testpmd"
-  interface:
-    pf1:
-      name: "ens7f3"
-      pci: "0000:ca:00.3"
-    vf1:
-      name: "ens7f3v0"
-      pci: "0000:ca:19.0"
-trafficgen:
-  host: "TrafficGen ip address"
-  username: root
-  password: "root password"
-  interface:
-    pf1:
-      name: "ens8f0"
-      mac: "40:a6:b7:2b:19:a0"
+

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -10,7 +10,8 @@ from sriov.common.utils import cleanup_after_ping, reset_mtu, set_pipefail
 def get_settings_obj() -> Config:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     config_file = script_dir + "/config.yaml"
-    return Config(config_file)
+    testbed_file = script_dir + "/testbed.yaml"
+    return Config(config_file, testbed_file)
 
 
 def get_ssh_obj(name: str) -> ShellHandler:

--- a/sriov/tests/testbed_template.yaml
+++ b/sriov/tests/testbed_template.yaml
@@ -1,0 +1,20 @@
+dut:
+  host: "DUT ip address"
+  username: root
+  password: "root password"
+  pmd_cpus: "cpu list that will be used to run testpmd on DUT"
+  interface:
+    pf1:
+      name: "ens7f3"
+      pci: "0000:ca:00.3"
+    vf1:
+      name: "ens7f3v0"
+      pci: "0000:ca:19.0"
+trafficgen:
+  host: "TrafficGen ip address"
+  username: root
+  password: "root password"
+  interface:
+    pf1:
+      name: "ens8f0"
+      mac: "40:a6:b7:2b:19:a0"


### PR DESCRIPTION
Current config.yaml has two parts, 
1) testbed info. This part of data define the testbed the script will be running on; it does not change the script behavior;
2) config data that can impact how script executes.

It's cleaner if we make them into two different files, one for the testbed definition; one for the script config.