### PR TITLE
Use create_vfs to replace create_vf in test_utils.py

### DIFF
--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -6,18 +6,8 @@ from sriov.common.utils import (
     execute_and_assert,
     get_intf_mac,
     get_pci_address,
+    create_vfs
 )
-
-
-def create_vf(dut, pf_name):
-    steps = [
-        f"echo 0 > /sys/class/net/{pf_name}/device/sriov_numvfs",
-        f"echo 1 > /sys/class/net/{pf_name}/device/sriov_numvfs",
-    ]
-    for step in steps:
-        code, _, err = dut.execute(step)
-        assert code == 0, err
-        time.sleep(0.1)
 
 
 def test_get_pci_address(dut, settings):
@@ -25,7 +15,7 @@ def test_get_pci_address(dut, settings):
     pf_name = settings.config["dut"]["interface"]["pf1"]["name"]
     assert pf_pci == get_pci_address(dut, pf_name)
 
-    create_vf(dut, pf_name)
+    assert create_vfs(dut, pf_name, 1)
     vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
     vf_name = settings.config["dut"]["interface"]["vf1"]["name"]
     assert vf_pci == get_pci_address(dut, vf_name)
@@ -33,13 +23,13 @@ def test_get_pci_address(dut, settings):
 
 def test_bind_driver(dut, settings):
     pf_name = settings.config["dut"]["interface"]["pf1"]["name"]
-    create_vf(dut, pf_name)
+    assert create_vfs(dut, pf_name, 1)
     vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
     assert bind_driver(dut, vf_pci, "vfio-pci")
 
 
 def test_tmux(dut, testdata):
-    name = testdata["tmux_session_name"]
+    name = testdata.tmux_session_name
     start_tmux(dut, name, "sleep 8")
     stop_tmux(dut, name)
 

--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -1,4 +1,3 @@
-import time
 from sriov.common.utils import (
     bind_driver,
     start_tmux,


### PR DESCRIPTION
common/test_exec.py::test_execute_cmd_success PASSED                                                                                                                         [  9%]
common/test_exec.py::test_execute_cmd_fail PASSED                                                                                                                            [ 18%]
common/test_exec.py::test_execute_cmd_timeout PASSED                                                                                                                         [ 27%]
common/test_exec.py::test_execute_cmd_with_delay PASSED                                                                                                                      [ 36%]
common/test_exec.py::test_start_and_stop_testpmd PASSED                                                                                                                      [ 45%]
common/test_utils.py::test_get_pci_address PASSED                                                                                                                            [ 54%]
common/test_utils.py::test_bind_driver PASSED                                                                                                                                [ 63%]
common/test_utils.py::test_tmux PASSED                                                                                                                                       [ 72%]
common/test_utils.py::test_get_intf_mac PASSED                                                                                                                               [ 81%]
common/test_utils.py::test_set_pipefail PASSED                                                                                                                               [ 90%]
common/test_utils.py::test_execute_and_assert PASSED 