### PR TITLE
Fix SR_IOV_Permutation_DPDK timing issue with in-tree drivers

### DIFF
--- a/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
+++ b/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
@@ -43,9 +43,9 @@ def test_SR_IOV_Permutation_DPDK(
     assert create_vfs(dut, pf, 1)
 
     # Another timing issue: 1 sec sleep after vf creation and mac assignment
-    # is required for some reason for successful VF mac address setting with 
+    # is required for some reason for successful VF mac address setting with
     # in-tree drivers and trust mode on
-     
+
     if trust == "on":
         sleep(1)
 

--- a/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
+++ b/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
@@ -1,4 +1,5 @@
 import pytest
+from time import sleep
 from sriov.common.utils import (
     create_vfs,
     set_vf_mac,
@@ -41,7 +42,17 @@ def test_SR_IOV_Permutation_DPDK(
 
     assert create_vfs(dut, pf, 1)
 
+    # Another timing issue: 1 sec sleep after vf creation and mac assignment
+    # is required for some reason for successful VF mac address setting with 
+    # in-tree drivers and trust mode on
+     
+    if trust == "on":
+        sleep(1)
+
     assert set_vf_mac(dut, pf, 0, testdata.dut_mac)
+
+    if trust == "on":
+        sleep(1)
 
     steps = [
         f"ip link set {pf} vf 0 spoof {spoof}",


### PR DESCRIPTION
This is a draft solution for #76. Please advise if you see a better option.
SR_IOV_Permutation_DPDK showed consistent failures in mac address change for every trust mode = on permutation with in-tree drivers:https://issues.redhat.com/secure/attachment/12751859/report86_RT_intree.html . Manual execution is fine even if you copy/paste all cli commands at once. Automated execution requires additional delays for every trust mode = on permutation [for some reason].
Passed log after the fix: https://issues.redhat.com/secure/attachment/12752326/report86_RT_intree_with_timing_fix.html 