### PR TITLE
Adding a new test case: DPDK VF Bonding

### DIFF
--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -14,6 +14,7 @@ class ConfigTestData:
         self.dut_mac = "aa:bb:cc:dd:ee:00"
         self.dut_spoof_mac = "aa:bb:cc:dd:ee:ff"
         self.trafficgen_ip = "101.1.1.1"
+        self.trafficgen_spoof_mac = "b4:96:91:00:00:00"
         self.qos = 5
         self.max_tx_rate = 10
         self.pfs = {}

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -653,3 +653,21 @@ def execute_until_timeout(ssh_obj: ShellHandler, cmd: str, timeout: int = 10) ->
         time.sleep(1)
     print("\nstdout:" + str(out) + "\nstderr:" + str(err))
     return False
+
+def wait_tmux_testpmd_ready(ssh_obj: ShellHandler, tmux_session: str, timeout: int) -> bool:
+    for i in range(timeout):
+        time.sleep(1)
+        cmd = [f"tmux capture-pane -pt {tmux_session}"]
+        outs, errs = execute_and_assert(ssh_obj, cmd, 0)
+        started = False
+        for line in outs[0]:
+            if line.startswith("Press enter to exit"):
+                return True
+    return False
+
+def stop_testpmd_in_tmux(ssh_obj: ShellHandler, tmux_session: str):
+    cmd = f"tmux send-keys -t {tmux_session} 'quit' ENTER"
+    ssh_obj.log_str(cmd)
+    ssh_obj.execute(cmd)
+    time.sleep(1)
+    assert stop_tmux(ssh_obj, tmux_session)

--- a/sriov/tests/SR_IOV_BondVF_DPDK/README.md
+++ b/sriov/tests/SR_IOV_BondVF_DPDK/README.md
@@ -1,0 +1,50 @@
+## Test Case Name: SR-IOV.BondVF.DPDK
+
+### Objective(s): Test and ensure that VFs DPDK bond (mode 0, 1) across PFs work as expected.
+
+### Test procedure
+
+* On DUT, create 2 VF on PF 1 and 1 VF on PF 2; set trust mode on; and set a specific mac address under PF1 VF 1,
+```
+echo 2 > /sys/class/net/${PF_1}/device/sriov_numvfs
+echo 1 > /sys/class/net/${PF_2}/device/sriov_numvfs
+ip link set ${PF_1} vf 0 trust on
+ip link set ${PF_1} vf 1 trust on
+ip link set ${PF_2} vf 0 trust on
+ip link set ${PF_1} VF 1 mac ${PF_1_VF_1_MAC}
+```
+
+* On DUT, get the PCI address for each VF. Compare the PCI address PF_1 VF 1 and PF_2 VF 0, if PF_1 VF 1 has a smaller PCI address, set IN_NUM=1; else set IN_NUM=2
+
+* On DUT, bind all VFs to vfio-pci
+
+* On DUT, start a tmux session and run testpmd in the tmux session, for example,
+```
+podman run -it --rm --privileged -v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules --cpuset-cpus 30,32,34 docker.io/patrickkutch/dpdk:v21.11 dpdk-testpmd -l 30,32,34 -n 4 -a ${PF_1_VF_0_PCI} -a ${PF_1_VF_1_PCI} -a ${PF_2_VF_0_PCI} --vdev net_bonding_bond_test,mode=${MODE},slave=${PF_1_VF_0_PCI},slave=${PF_2_VF_0_PCI},primary=${PF_1_VF_0_PCI} -- --forward-mode=mac --stats-period=1 --portlist ${IN_NUM},3 --eth-peer 3,dd:cc:bb:aa:33:00
+```
+
+* On trafficgen, prepare for ping test,
+```
+ip address add ${PING_IP}/24 dev ${TGEN_PF_1}
+arp -s ${PING_IP} {PF_1_VF_1_MAC}
+```
+
+* On trafficgen, start a tmux session to continuously send ping packets to ${PING_IP}
+
+* On trafficgen, use tcpdump to validate the ping packets are received on the TGEN_PF_1
+
+* For active-backup (mode 1), on DUT, disable PF_1_VF_0,
+```
+ip link set ${PF_1} vf 0 state disable
+```
+
+* On trafficgen, use tcpdump to validate the ping packets are received on the TGEN_PF_2
+
+* This step is for active-backup mode only. On DUT, enable VF 0; On trafficgen, use tcpdump to validate the ping packets are received on the TGEN_PF_1
+
+
+### Clean up
+
+On trafficgen, delete the ping tmux session
+On DUT, in the testpmd tmux window, enter “quit\n”, then delete testpmd tmux session, and reset the VFs
+

--- a/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
+++ b/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
@@ -1,0 +1,110 @@
+import pytest
+from time import sleep
+from sriov.common.utils import (
+    create_vfs,
+    set_vf_mac,
+    execute_and_assert,
+    bind_driver,
+    prepare_ping_test,
+    get_pci_address,
+    start_tmux,
+    wait_tmux_testpmd_ready,
+    stop_tmux,
+    stop_testpmd_in_tmux,
+)
+
+
+@pytest.mark.parametrize("mode", (0, 1))
+def test_SR_IOV_Permutation_DPDK(
+    dut, trafficgen, settings, testdata, mode
+):
+    """Test VFs function when bound to the DPDK driver with various properties
+
+    Args:
+        dut:         ssh connection obj
+        trafficgen:  trafficgen obj
+        settings:    settings obj
+        testdata:    testdata obj
+        spoof:       spoof parameter
+        trust:       trust parameter
+        qos:         qos parameter
+        vlan:        vlan parameter
+        max_tx_rate: max_tx_rate parameter
+    """
+    pf1 = settings.config["dut"]["interface"]["pf1"]["name"]
+    assert create_vfs(dut, pf1, 2)
+    pf2 = settings.config["dut"]["interface"]["pf2"]["name"]
+    assert create_vfs(dut, pf2, 1)
+
+    sleep(1)
+    assert set_vf_mac(dut, pf1, 1, testdata.dut_mac)
+    sleep(1)
+
+    steps = [
+        f"ip link set {pf1} vf 0 trust on",
+        f"ip link set {pf1} vf 1 trust on",
+        f"ip link set {pf2} vf 0 trust on",
+    ]
+
+    execute_and_assert(dut, steps, 0, 0.1)
+
+    pci_pf1_vf0 = get_pci_address(dut, pf1+"v0")
+    assert bind_driver(dut, pci_pf1_vf0, "vfio-pci")
+    pci_pf1_vf1 = get_pci_address(dut, pf1+"v1")
+    assert bind_driver(dut, pci_pf1_vf1, "vfio-pci")
+    pci_pf2_vf0 = get_pci_address(dut, pf2+"v0")
+    assert bind_driver(dut, pci_pf2_vf0, "vfio-pci") 
+    rx_port_num = 1 if pci_pf1_vf1 < pci_pf2_vf0 else 2
+    fwd_mac = "dd:cc:bb:aa:33:00"
+    dpdk_img = settings.config["dpdk_img"]
+    cpus = settings.config["dut"]["pmd_cpus"]
+    podman_cmd = f"""podman run -it --rm --privileged \
+        -v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules \
+        --cpuset-cpus {cpus} {dpdk_img} \
+        dpdk-testpmd -l {cpus} -n 4 \
+        -a {pci_pf1_vf0} -a {pci_pf1_vf1} -a {pci_pf2_vf0} \
+        --vdev net_bonding_bond_test,mode=1,slave={pci_pf1_vf0},slave={pci_pf2_vf0},primary={pci_pf1_vf0} \
+        -- --forward-mode=mac --portlist {rx_port_num},3 \
+        --eth-peer 3,{fwd_mac}"""
+    dut.log_str(podman_cmd)
+    testpmd_tmux_session = testdata.tmux_session_name
+    assert start_tmux(dut, testpmd_tmux_session, podman_cmd)
+    assert wait_tmux_testpmd_ready(dut, testpmd_tmux_session, 10)
+
+    trafficgen_pf1 = settings.config["trafficgen"]["interface"]["pf1"]["name"]
+    trafficgen_pf2 = settings.config["trafficgen"]["interface"]["pf2"]["name"]
+    trafficgen_ip = testdata.trafficgen_ip
+    dut_ip = testdata.dut_ip
+    assert prepare_ping_test(
+        trafficgen,
+        trafficgen_pf1,
+        0,
+        trafficgen_ip,
+        None,
+        dut,
+        dut_ip,
+        testdata.dut_mac,
+        testdata,
+    )
+    
+    ping_cmd = f"ping -i 0.3 {dut_ip}"
+    trafficgen.log_str(ping_cmd)
+    ping_tmux_session = "dpdk_bonding_ping"
+    assert start_tmux(trafficgen, ping_tmux_session, ping_cmd)
+    
+    tcpdump_cmd = f"timeout 3 tcpdump -i {trafficgen_pf1} -c 1 ether host {fwd_mac}"
+    code_primary_link, out, err = trafficgen.execute(tcpdump_cmd)
+
+    link_down_cmd = f"ip link set {pf1} vf 0 state disable"
+    execute_and_assert(dut, [link_down_cmd], 0)
+    
+    tcpdump_cmd = f"timeout 3 tcpdump -i {trafficgen_pf2} -c 1 ether host {fwd_mac}"
+    code_backup_link, out, err = trafficgen.execute(tcpdump_cmd)
+    
+    stop_tmux(trafficgen, ping_tmux_session)
+    stop_testpmd_in_tmux(dut, testpmd_tmux_session)
+    assert code_primary_link == 0
+    assert code_backup_link == 0
+
+
+    

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -82,8 +82,12 @@ def _cleanup(
     yield
     # For debug test failure purpose,
     # use --skipclean to stop the test immediately without cleaning
-    if request.node.rep_call.failed and skipclean:
-        pytest.exit("stop the test run without cleanup")
+    try:
+        if request.node.rep_call.failed and skipclean:
+            pytest.exit("stop the test run without cleanup")
+    except:
+        # most likely request.node.rep_call not exist, continue normal cleanup
+        pass
     dut.stop_testpmd()
     assert cleanup_after_ping(trafficgen, dut, testdata)
     assert reset_mtu(trafficgen, dut, testdata)


### PR DESCRIPTION
This is a difficult test case and really need some explanation for how it was automated. Two key tricks used for this bonding test case,

1) have a sperare  pytest.fixture for setup and cleanup
When a test fail, pytest will skip the test code after the assertion line. So cleanup code has to live outside the test case function. Normally we rely on the common cleanup steps in the conftest to do the cleanup. That works for common clean up steps, such as reset the VFs, as we know for sure we need to reset the VF after each test, and it is the same steps to reset the VFs. For clean up steps not common, for example terminating a testpmd instance and its associated tmux session, it is more appropriate to do it next to the setup code, as the steps to take for the clean up depend on the setup steps. Using a pytest.fixture with both setup and cleanup at the test file level appears to serve this well

2) parametrize the pytest.fixture at the test file level
Here we use a good trick. The bonding mode (0 or 1) is passed as "indirect" to the  pytest.fixture(for setup/cleanup), then the pytest.fixture pass it back to the test function. 