### PR TITLE
Hotfix: execute() fails to return cmd output on a XR-12 server

### DIFF
--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -248,11 +248,11 @@ class ShellHandler:
         # first and last lines of shout/sherr contain a prompt
         if shout and echo_cmd in shout[-1]:
             shout.pop()
-        if shout and shout[0].endswith(cmd + "\n"):
+        if shout and len(shout) > 1 and cmd in shout[0]:
             shout.pop(0)
         if sherr and echo_cmd in sherr[-1]:
             sherr.pop()
-        if sherr and len(sherr) > 1 and sherr[0].endswith(cmd + "\n"):
+        if sherr and len(sherr) > 1 and cmd in sherr[0]:
             sherr.pop(0)
 
         return exit_status, shout, sherr


### PR DESCRIPTION
On a new XR-12 DELL server, when execute a command over the ssh session, for some reason, an extra character was append to the end of the command line. For example, the script sends "cat /sys/kernel/mm/hugepages/hugepages-1048576kB/free_hugepages', the machine echo back: "cat /sys/kernel/mm/hugepages/hugepages-1048576kB/free_hugepagess\n", e.g., an extra 's' is appended to the echoed cmd string. This cause the execute() fails to strip the echoed cmd from its buffer and causes output error. The reason why the extra 's' is generated on XR12 is a TBD, but we need a workaround.

With this fix, all test cases runs fine (except the know failure on DPDK bonding):
https://gist.githubusercontent.com/jianzzha/19014fbba69feac0e397d3c01b0d41ff/raw/75dff4f1cef0c50ad669a24dbb26c941a16c9254/gistfile1.txt